### PR TITLE
replace generic exceptions with specific library exceptions

### DIFF
--- a/benchmarks/src/main/SerializationException.java
+++ b/benchmarks/src/main/SerializationException.java
@@ -1,0 +1,7 @@
+package com.esotericsoftware.kryo.benchmarks;
+
+public class SerializationException extends RuntimeException {
+    public SerializationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/ConcurrencyBenchmark.java
+++ b/benchmarks/src/main/java/com/esotericsoftware/kryo/benchmarks/ConcurrencyBenchmark.java
@@ -141,8 +141,8 @@ public class ConcurrencyBenchmark {
 				output.flush();
 				return stream.toByteArray();
 			} catch (IOException e) {
-				 throw new RuntimeException(e); 
-				 	} finally {
+				 throw new SerializationException("Error during serialization", e);
+			} finally {
 				output.reset();
 			}
 		}


### PR DESCRIPTION
Bug :
The AbstractConcurrencyState.serialize() method was throwing a generic RuntimeException when an IOException occurred during serialization. This made it difficult to identify the root cause and violated clean code and SonarCloud recommendations for using specific or custom exceptions.

To Reproduce
Run any Kryo serialization benchmark (e.g., ConcurrencyBenchmark).
Trigger an I/O failure during the serialize() process (e.g., invalid output stream).
Observe that the code throws a generic RuntimeException without meaningful context.

Expected behavior:
A meaningful, domain-specific exception should be thrown to clearly indicate that the failure occurred during serialization.